### PR TITLE
Fix build script directory traversal

### DIFF
--- a/build.xsh
+++ b/build.xsh
@@ -24,5 +24,5 @@ for dir in files.keys():
     cd @('../../bin/'+ARCH+'/'+dir[0])
     for file in files[dir]:
         ln -s @(dir[1]+'.so') @(file+'.so')
-    cd ..
+    cd ../../../bindings
 cd ..


### PR DESCRIPTION
Previously, cd would throw an error about not being able to find a directory.