### PR TITLE
Use pybind11 from a git submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "extern/pybind11"]
+	path = extern/pybind11
+	url = ../../pybind/pybind11
+	branch = stable

--- a/Jamfile
+++ b/Jamfile
@@ -66,7 +66,7 @@ rule Symlink
 ## Main build file
 
 # Set user configurable variables to default value if user did not specify value
-py ?= 3.10 ;
+py ?= 3.12 ;
 python_version ?= $(py) ;
 install_location ?=
 	/boot/system/non-packaged/lib/python$(python_version)/site-packages ;
@@ -75,7 +75,7 @@ install_location ?=
 SEARCH_SOURCE += bindings/interface bindings/app ;
 
 # Where to look for header files
-SubDirHdrs /system/lib/python$(python_version)/vendor-packages/pybind11/include/ ;
+SubDirHdrs extern/pybind11/include/ ;
 SubDirHdrs /system/develop/headers/python$(python_version)/ ;
 
 # Additional C++ flags to use when compiling


### PR DESCRIPTION
Hi.

I'm opening this as draft, as it is not my intention to have this merged, but just to present it as an alternative usage of pybind11 (one that doesn't relies on Haiku having it packaged for each and every Python version).

---

Relevant docs from pybind11: https://pybind11.readthedocs.io/en/stable/installing.html#include-as-a-submodule

---

Also, I'm assuming that `git submodule update --init` needs to be ran at least once from existing PyAPI repo clones, or `git clone --recurse-submodules` used for new clones, before attempting to `jam` it.

I've build it this way for Python 3.11 and 3.12 on 64 bits, and smoke-tested it with `python3.1{1,2} test.py`.

Python 3.11 seems to work fine, while 3.12 crashes upon clicking on the "Say Hello" button, with 
`pybind11::gil_scoped_release::gil_scoped_release(bool)` appearing on the Debugger's `.report` (Python 3.12+ will be "fun" regarding GIL-related errors).