### PR TITLE
Enable ColorControl and Point

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -133,7 +133,9 @@ local sourceFiles =
 	SeparatorItem.cpp
 	MenuBar.cpp
 	StatusBar.cpp
-	CheckBox.cpp ;
+	CheckBox.cpp 
+	Point.cpp
+	ColorControl.cpp ;
 
 # The shared library Be.so can be built from the sourceFiles
 SharedLibrary Be.so : $(sourceFiles) ;

--- a/Jamfile
+++ b/Jamfile
@@ -135,7 +135,9 @@ local sourceFiles =
 	StatusBar.cpp
 	CheckBox.cpp 
 	Point.cpp
-	ColorControl.cpp ;
+	ColorControl.cpp 
+	RadioButton.cpp
+	;
 
 # The shared library Be.so can be built from the sourceFiles
 SharedLibrary Be.so : $(sourceFiles) ;

--- a/Jamfile
+++ b/Jamfile
@@ -132,7 +132,8 @@ local sourceFiles =
 	Box.cpp
 	SeparatorItem.cpp
 	MenuBar.cpp
-	StatusBar.cpp ;
+	StatusBar.cpp
+	CheckBox.cpp ;
 
 # The shared library Be.so can be built from the sourceFiles
 SharedLibrary Be.so : $(sourceFiles) ;

--- a/Jamfile
+++ b/Jamfile
@@ -131,7 +131,8 @@ local sourceFiles =
 	PopUpMenu.cpp
 	Box.cpp
 	SeparatorItem.cpp
-	MenuBar.cpp ;
+	MenuBar.cpp
+	StatusBar.cpp ;
 
 # The shared library Be.so can be built from the sourceFiles
 SharedLibrary Be.so : $(sourceFiles) ;

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -43,6 +43,7 @@ from .StatusBar import *
 from .CheckBox import *
 from .Point import *
 from .ColorControl import *
+from .RadioButton import *
 
 _BWindow=BWindow
 _BApplication=BApplication

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -39,7 +39,7 @@ from .PopUpMenu import *
 from .Box import *
 from .SeparatorItem import *
 from .MenuBar import *
-
+from .StatusBar import *
 
 _BWindow=BWindow
 _BApplication=BApplication

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -41,6 +41,8 @@ from .SeparatorItem import *
 from .MenuBar import *
 from .StatusBar import *
 from .CheckBox import *
+from .Point import *
+from .ColorControl import *
 
 _BWindow=BWindow
 _BApplication=BApplication

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -40,6 +40,7 @@ from .Box import *
 from .SeparatorItem import *
 from .MenuBar import *
 from .StatusBar import *
+from .CheckBox import *
 
 _BWindow=BWindow
 _BApplication=BApplication

--- a/bindings/interface/CheckBox.cpp
+++ b/bindings/interface/CheckBox.cpp
@@ -4,6 +4,7 @@
 #include <pybind11/operators.h>
 
 #include <interface/CheckBox.h>
+#include <interface/Bitmap.h>
 #include <Control.h>
 
 namespace py = pybind11;
@@ -11,7 +12,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(CheckBox,m)
 {
-py::class_<BCheckBox, BControl>(m, "BCheckBox")
+py::class_<BCheckBox, BControl, std::unique_ptr<BCheckBox, py::nodelete>>(m, "BCheckBox")
 .def(py::init<BRect, const char *, const char *, BMessage *, unsigned int, unsigned int>(), "", py::arg("frame"), py::arg("name"), py::arg("label"), py::arg("message"), py::arg("resizingMode")=B_FOLLOW_LEFT_TOP, py::arg("flags")=B_WILL_DRAW | B_NAVIGABLE)
 .def(py::init<const char *, const char *, BMessage *, unsigned int>(), "", py::arg("name"), py::arg("label"), py::arg("message"), py::arg("flags")=B_WILL_DRAW | B_NAVIGABLE)
 .def(py::init<const char *, BMessage *>(), "", py::arg("label"), py::arg("message")=NULL)

--- a/bindings/interface/ColorControl.cpp
+++ b/bindings/interface/ColorControl.cpp
@@ -27,7 +27,7 @@ py::class_<BColorControl, BControl,std::unique_ptr<BColorControl, py::nodelete>>
 .def_static("Instantiate", &BColorControl::Instantiate, "", py::arg("data"))
 .def("Archive", &BColorControl::Archive, "", py::arg("data"), py::arg("deep")=true)
 .def("SetLayout", py::overload_cast<BLayout *>(&BColorControl::SetLayout), "", py::arg("layout"))
-.def("SetValue", py::overload_cast<int>(&BColorControl::SetValue), "", py::arg("color_value"))
+.def("SetValue", py::overload_cast<int32>(&BColorControl::SetValue), "", py::arg("color_value"))
 .def("SetValue", py::overload_cast<rgb_color>(&BColorControl::SetValue), "", py::arg("color"))
 .def("ValueAsColor", &BColorControl::ValueAsColor, "")
 .def("SetEnabled", &BColorControl::SetEnabled, "", py::arg("state"))

--- a/bindings/interface/ColorControl.cpp
+++ b/bindings/interface/ColorControl.cpp
@@ -4,6 +4,8 @@
 #include <pybind11/operators.h>
 
 #include <interface/ColorControl.h>
+#include <interface/Layout.h>
+#include <interface/Bitmap.h>
 #include <Control.h>
 
 namespace py = pybind11;
@@ -19,7 +21,7 @@ py::enum_<color_control_layout>(m, "color_control_layout", "")
 .value("B_CELLS_64x4", color_control_layout::B_CELLS_64x4, "")
 .export_values();
 
-py::class_<BColorControl, BControl>(m, "BColorControl")
+py::class_<BColorControl, BControl,std::unique_ptr<BColorControl, py::nodelete>>(m, "BColorControl")
 .def(py::init<BPoint, color_control_layout, float, const char *, BMessage *, bool>(), "", py::arg("start"), py::arg("layout"), py::arg("cellSize"), py::arg("name"), py::arg("message")=NULL, py::arg("useOffscreen")=false)
 .def(py::init<BMessage *>(), "", py::arg("data"))
 .def_static("Instantiate", &BColorControl::Instantiate, "", py::arg("data"))

--- a/bindings/interface/Point.cpp
+++ b/bindings/interface/Point.cpp
@@ -12,7 +12,6 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(Point,m)
 {
-//m.attr("B_ORIGIN") = B_ORIGIN;
 
 py::class_<BPoint>(m, "BPoint")
 .def(py::init(), "")
@@ -43,5 +42,6 @@ py::class_<BPoint>(m, "BPoint")
 ;
 
 //m.def("operator=", &operator=, "", py::arg("other"));
+m.attr("B_ORIGIN") = B_ORIGIN;
 
 }

--- a/bindings/interface/Point.cpp
+++ b/bindings/interface/Point.cpp
@@ -5,13 +5,14 @@
 
 #include <interface/Point.h>
 #include <SupportDefs.h>
+#include <interface/Rect.h>
 
 namespace py = pybind11;
 
 
 PYBIND11_MODULE(Point,m)
 {
-m.attr("B_ORIGIN") = B_ORIGIN;
+//m.attr("B_ORIGIN") = B_ORIGIN;
 
 py::class_<BPoint>(m, "BPoint")
 .def(py::init(), "")
@@ -21,17 +22,26 @@ py::class_<BPoint>(m, "BPoint")
 .def("Set", &BPoint::Set, "", py::arg("x"), py::arg("y"))
 .def("ConstrainTo", &BPoint::ConstrainTo, "", py::arg("rect"))
 .def("PrintToStream", &BPoint::PrintToStream, "")
-.def("operator-", py::overload_cast<>(&BPoint::operator-), "")
+//.def("operator-", py::overload_cast<>(&BPoint::operator-), "")
+//.def("__neg__", py::overload_cast<>(&BPoint::operator-), "")
+//.def("__neg__", &BPoint::operator-, "")
+.def("__neg__", [](const BPoint &self) { return -self; })
 .def("__add__", &BPoint::operator+, "", py::arg("other"))
-.def("operator-", py::overload_cast<const BPoint &>(&BPoint::operator-), "", py::arg("other"))
+//.def("operator-", py::overload_cast<const BPoint &>(&BPoint::operator-), "", py::arg("other"))
+//.def("__sub__", py::overload_cast<const BPoint &>(&BPoint::operator-), "", py::arg("other"))
+//.def("__sub__", &BPoint::operator-, "", py::arg("other"))
+.def("__sub__", [](const BPoint &self, const BPoint &other) { return self - other; }, py::arg("other"))
 .def("__iadd__", &BPoint::operator+=, "", py::arg("other"))
 .def("__isub__", &BPoint::operator-=, "", py::arg("other"))
 .def("__ne__", &BPoint::operator!=, "", py::arg("other"))
 .def("__eq__", &BPoint::operator==, "", py::arg("other"))
+//.def("BPoint", &BPoint::BPoint, "")
+//.def("BPoint", &BPoint::BPoint, "",py::arg("x"),py::arg("y"))
+//.def("BPoint", py::overload_cast<const BPoint>(&BPoint::BPoint), "", py::arg("other"))
 .def_readwrite("x", &BPoint::x, "")
 .def_readwrite("y", &BPoint::y, "")
 ;
 
-m.def("operator=", &operator=, "", py::arg("other"));
+//m.def("operator=", &operator=, "", py::arg("other"));
 
 }

--- a/bindings/interface/RadioButton.cpp
+++ b/bindings/interface/RadioButton.cpp
@@ -12,7 +12,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(RadioButton,m)
 {
-py::class_<BRadioButton, BControl>(m, "BRadioButton")
+py::class_<BRadioButton, BControl,std::unique_ptr<BRadioButton, py::nodelete>>(m, "BRadioButton")
 .def(py::init<BRect, const char *, const char *, BMessage *, unsigned int, unsigned int>(), "", py::arg("frame"), py::arg("name"), py::arg("label"), py::arg("message"), py::arg("resizingMode")=B_FOLLOW_LEFT_TOP, py::arg("flags")=B_WILL_DRAW | B_NAVIGABLE)
 .def(py::init<const char *, const char *, BMessage *, unsigned int>(), "", py::arg("name"), py::arg("label"), py::arg("message"), py::arg("flags")=B_WILL_DRAW | B_NAVIGABLE)
 .def(py::init<const char *, BMessage *>(), "", py::arg("label"), py::arg("message"))

--- a/bindings/interface/TextControl.cpp
+++ b/bindings/interface/TextControl.cpp
@@ -15,7 +15,7 @@ PYBIND11_MODULE(TextControl,m)
 {
 
 
-py::class_<BTextControl, BControl>(m, "BTextControl")
+py::class_<BTextControl, BControl, std::unique_ptr<BTextControl, py::nodelete>>(m, "BTextControl")
 .def(py::init<BRect, const char *, const char *, const char *, BMessage *, unsigned int, unsigned int>(), "", py::arg("frame"), py::arg("name"), py::arg("label"), py::arg("initialText"), py::arg("message"), py::arg("resizeMask")=B_FOLLOW_LEFT_TOP, py::arg("flags")=B_WILL_DRAW | B_NAVIGABLE)
 .def(py::init<const char *, const char *, const char *, BMessage *, unsigned int>(), "", py::arg("name"), py::arg("label"), py::arg("initialText"), py::arg("message"), py::arg("flags")=B_WILL_DRAW | B_NAVIGABLE)
 .def(py::init<const char *, const char *, BMessage *>(), "", py::arg("label"), py::arg("initialText"), py::arg("message"))

--- a/tmtest.py
+++ b/tmtest.py
@@ -1,4 +1,6 @@
-from Be import BApplication, BWindow,BBox, BCheckBox,BRect,BTextControl, BView,BMenu,BStatusBar, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
+from Be import BApplication, BWindow, BAlert, BPoint, BBox, BColorControl, BCheckBox, BRect, BTextControl, BView,BMenu,BStatusBar, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
+from Be.Alert import alert_type
+from Be.ColorControl import color_control_layout
 from Be import InterfaceDefs
 from Be import AppDefs
 
@@ -8,6 +10,8 @@ class Window(BWindow):
 		('File', ((1, 'asd'),(2, 'lol'),(5, 'bubu'),(None, None),(AppDefs.B_QUIT_REQUESTED, 'Quit'))),
 		('Help', ((8, 'Help'),(3, 'About')))
 		)
+	CLRCTL = 4
+	
 	def __init__(self):
 		BWindow.__init__(self, BRect(100,100,600,750), "Hello Haiku!", window_type.B_TITLED_WINDOW,  B_NOT_RESIZABLE | B_QUIT_ON_WINDOW_CLOSE)
 		bounds=self.Bounds()
@@ -21,6 +25,9 @@ class Window(BWindow):
 		self.tachetest=BTextControl(BRect(57,bounds.Height()-30,bounds.Width()-57,bounds.Height()-12),'TxTView', "prova:",None,BMessage(1),0x0202|0x0404)
 		self.tachetest.SetDivider(55.0)
 		self.startimer= BCheckBox(BRect(10,30,290,50),'Testbox','Test Checkbox',BMessage(612))
+		self.point=BPoint()
+		self.cc= BColorControl(BPoint(8, 128), color_control_layout.B_CELLS_32x8, 8.0,'colors', BMessage(self.CLRCTL), 0)
+		self.panel.AddChild(self.cc,None)
 		self.panel.AddChild(self.startimer,None)
 		self.panel.AddChild(self.tachetest,None)
 		self.panel.AddChild(self.statbar,None)
@@ -36,11 +43,22 @@ class Window(BWindow):
 		self.AddChild(self.panel,None)
 		
 	def MessageReceived(self, msg):
-		if msg.what == 2:
+		if msg.what == 1:
+			self.startimer.SetValue(not(self.startimer.Value()))
+		elif msg.what == 2:
 			x=round(self.statbar.CurrentValue())
 			if x<100:
 				outtxt=str(x+1)+"%"
 				self.statbar.Update(1.0,outtxt,"100%")
+		elif msg.what == 8:
+			ask = BAlert('Whoa!', 'Are you sure you need help?', 'Yes','No', None, InterfaceDefs.B_WIDTH_AS_USUAL, alert_type.B_IDEA_ALERT)
+			answ=ask.Go()
+			if answ==0:
+				risp = BAlert('lol', 'Well there\'s no help manual here', 'Bummer', None,None,InterfaceDefs.B_WIDTH_AS_USUAL,alert_type.B_INFO_ALERT)
+				risp.Go()
+			else:
+				risp = BAlert('lol', 'If you think so...', 'Poor me', None,None,InterfaceDefs.B_WIDTH_AS_USUAL,alert_type.B_WARNING_ALERT)
+				risp.Go()
 		BWindow.MessageReceived(self, msg)
 		
 	def QuitRequested(self):

--- a/tmtest.py
+++ b/tmtest.py
@@ -1,4 +1,4 @@
-from Be import BApplication, BWindow,BBox, BRect, BView,BMenu, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
+from Be import BApplication, BWindow,BBox, BRect,BTextControl, BView,BMenu,BStatusBar, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
 from Be import InterfaceDefs
 from Be import AppDefs
 
@@ -9,16 +9,20 @@ class Window(BWindow):
 		('Help', ((8, 'Help'),(3, 'About')))
 		)
 	def __init__(self):
-		BWindow.__init__(self, BRect(100,100,200,150), "Hello Haiku!", window_type.B_TITLED_WINDOW,  B_NOT_RESIZABLE | B_QUIT_ON_WINDOW_CLOSE)
+		BWindow.__init__(self, BRect(100,100,600,750), "Hello Haiku!", window_type.B_TITLED_WINDOW,  B_NOT_RESIZABLE | B_QUIT_ON_WINDOW_CLOSE)
+		bounds=self.Bounds()
 		self.panel = BView(self.Bounds(), "panel", 8, 20000000)
-		self.underbox = BBox(self.panel.Bounds(),"underbox",0x0202|0x0404,InterfaceDefs.border_style.B_FANCY_BORDER)
-		self.box = BBox(BRect(10,20,90,45),"MYBox",0x0202|0x0404,InterfaceDefs.border_style.B_FANCY_BORDER)
+		self.box = BBox(BRect(10,26,90,51),"MYBox",0x0202|0x0404,InterfaceDefs.border_style.B_FANCY_BORDER)
 		self.bar = BMenuBar(self.box.Bounds(), 'Bar')
 		self.testo = BStringView(BRect(5,5,75,20), 'Test','prova')
 		self.box.AddChild(self.testo,None)
-		self.underbox.AddChild(self.box,None)
-		self.underbox.AddChild(self.bar,None)
-		self.panel.AddChild(self.underbox,None)
+		self.statbar = BStatusBar(BRect(10,70,bounds.Width()/3-15,144), 'progress','0%', '100%')
+		self.statbar.SetMaxValue(100.0)
+		self.tachetest=BTextControl(BRect(57,bounds.Height()-30,bounds.Width()-57,bounds.Height()-12),'TxTView', "prova:",None,BMessage(1),0x0202|0x0404)
+		self.tachetest.SetDivider(55.0)
+		self.panel.AddChild(self.tachetest,None)
+		self.panel.AddChild(self.statbar,None)
+		self.panel.AddChild(self.bar,None)
 		for menu, items in self.Menus:
 			menu = BMenu(menu)
 			for k, name in items:
@@ -27,15 +31,14 @@ class Window(BWindow):
 				else:
 						menu.AddItem(BMenuItem(name, BMessage(k),name[1],0))
 			self.bar.AddItem(menu)
-		if self.bar.FindItem("bubu"):
-			print("yay")
-		else:
-			print("noo")
-		print(self.bar.FindItem("lol"))#.SetMarked(0) not working not found 
 		self.AddChild(self.panel,None)
 		
 	def MessageReceived(self, msg):
-		print(msg)
+		if msg.what == 2:
+			x=round(self.statbar.CurrentValue())
+			if x<100:
+				outtxt=str(x+1)+"%"
+				self.statbar.Update(1.0,outtxt,"100%")
 		BWindow.MessageReceived(self, msg)
 		
 	def QuitRequested(self):

--- a/tmtest.py
+++ b/tmtest.py
@@ -25,8 +25,7 @@ class Window(BWindow):
 				if k is None:
 						menu.AddItem(BSeparatorItem())
 				else:
-						msg = BMessage(k)
-						menu.AddItem(BMenuItem(name, msg,name[1],0))
+						menu.AddItem(BMenuItem(name, BMessage(k),name[1],0))
 			self.bar.AddItem(menu)
 		if self.bar.FindItem("bubu"):
 			print("yay")
@@ -41,8 +40,7 @@ class Window(BWindow):
 		
 	def QuitRequested(self):
 		print ("So long and thanks for all the fish")
-		be_app.PostMessage(BMessage(AppDefs.B_QUIT_REQUESTED))
-		return 1
+		return BWindow.QuitRequested(self)
 		
 class App(BApplication):
     def __init__(self):

--- a/tmtest.py
+++ b/tmtest.py
@@ -1,4 +1,4 @@
-from Be import BApplication, BWindow, BAlert, BPoint, BBox, BColorControl, BCheckBox, BRect, BTextControl, BView,BMenu,BStatusBar, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
+from Be import BApplication, BWindow, BAlert, BPoint, BBox, BRadioButton, BColorControl, BCheckBox, BRect, BTextControl, BView,BMenu,BStatusBar, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
 from Be.Alert import alert_type
 from Be.ColorControl import color_control_layout
 from Be import InterfaceDefs
@@ -27,6 +27,12 @@ class Window(BWindow):
 		self.startimer= BCheckBox(BRect(10,30,290,50),'Testbox','Test Checkbox',BMessage(612))
 		self.point=BPoint()
 		self.cc= BColorControl(BPoint(8, 128), color_control_layout.B_CELLS_32x8, 8.0,'colors', BMessage(self.CLRCTL), 0)
+		self.sixradio = BRadioButton(BRect(8,220,24,236),'hotradio', 'hot', BMessage(6))
+		self.sevenradio = BRadioButton(BRect(8,236,24,252),'tepidradio', 'tepid', BMessage(7))
+		self.nineradio = BRadioButton(BRect(8,252,24,268),'coolradio', 'cool', BMessage(9))
+		self.panel.AddChild(self.sixradio,None)
+		self.panel.AddChild(self.sevenradio,None)
+		self.panel.AddChild(self.nineradio,None)
 		self.panel.AddChild(self.cc,None)
 		self.panel.AddChild(self.startimer,None)
 		self.panel.AddChild(self.tachetest,None)

--- a/tmtest.py
+++ b/tmtest.py
@@ -1,4 +1,4 @@
-from Be import BApplication, BWindow,BBox, BRect,BTextControl, BView,BMenu,BStatusBar, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
+from Be import BApplication, BWindow,BBox, BCheckBox,BRect,BTextControl, BView,BMenu,BStatusBar, BMenuBar, BMenuItem,BSeparatorItem,BStringView,BMessage,window_type,  B_NOT_RESIZABLE, B_QUIT_ON_WINDOW_CLOSE
 from Be import InterfaceDefs
 from Be import AppDefs
 
@@ -20,6 +20,8 @@ class Window(BWindow):
 		self.statbar.SetMaxValue(100.0)
 		self.tachetest=BTextControl(BRect(57,bounds.Height()-30,bounds.Width()-57,bounds.Height()-12),'TxTView', "prova:",None,BMessage(1),0x0202|0x0404)
 		self.tachetest.SetDivider(55.0)
+		self.startimer= BCheckBox(BRect(10,30,290,50),'Testbox','Test Checkbox',BMessage(612))
+		self.panel.AddChild(self.startimer,None)
 		self.panel.AddChild(self.tachetest,None)
 		self.panel.AddChild(self.statbar,None)
 		self.panel.AddChild(self.bar,None)


### PR DESCRIPTION
Still in BPoint I had to comment out:

//m.attr("B_ORIGIN") = B_ORIGIN;
//m.def("operator=", &operator=, "", py::arg("other"));

B_ORIGIN I think is an important costant, but If left uncommented I could not compile. Please, take a look