### PR TITLE
Fix BView detach callback dispatch

### DIFF
--- a/bindings/interface/View.cpp
+++ b/bindings/interface/View.cpp
@@ -49,10 +49,10 @@ class PyBView : public BView{
             PYBIND11_OVERLOAD(void, BView, AllAttached);
         }
         void				DetachedFromWindow() override {
-            PYBIND11_OVERLOAD(void, BView, AllAttached);
+            PYBIND11_OVERLOAD(void, BView, DetachedFromWindow);
         }
         void				AllDetached() override {
-            PYBIND11_OVERLOAD(void, BView, AllAttached);
+            PYBIND11_OVERLOAD(void, BView, AllDetached);
         }
         void				MessageReceived(BMessage* message) override {
             PYBIND11_OVERLOAD(void, BView, MessageReceived, message);

--- a/tests/viewDetachCallbacks.py
+++ b/tests/viewDetachCallbacks.py
@@ -1,0 +1,53 @@
+from Be import BApplication, BView
+
+
+EXPECTED_CALLBACKS = [
+    "DetachedFromWindow",
+    "AllDetached",
+]
+
+
+class CallbackProbe(BView):
+    def __init__(self):
+        BView.__init__(
+            self,
+            "callback-probe",
+            0,
+            None,
+        )
+        self.calls = []
+
+    def AllAttached(self):
+        self.calls.append("AllAttached")
+
+    def DetachedFromWindow(self):
+        self.calls.append("DetachedFromWindow")
+
+    def AllDetached(self):
+        self.calls.append("AllDetached")
+
+
+def main():
+    application = BApplication(
+        "application/x-vnd.haiku-pyapi-view-detach-callback-test"
+    )
+    view = CallbackProbe()
+
+    BView.DetachedFromWindow(view)
+    BView.AllDetached(view)
+
+    if view.calls != EXPECTED_CALLBACKS:
+        raise SystemExit(
+            "FAIL: incorrect detach callback dispatch: "
+            f"{view.calls!r}"
+        )
+
+    print("callbacks =", view.calls)
+    print("VIEW DETACH CALLBACK REGRESSION TEST: PASS")
+
+    # Keep the BApplication alive until the probe has completed.
+    del application
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The BView trampolines for DetachedFromWindow() and AllDetached() both dispatch to the Python AllAttached() override.

Python subclasses therefore receive the wrong lifecycle callback when a view is detached.

## Fix

Dispatch each trampoline to its matching Python override.

## Validation

Verified that the bound base methods now invoke DetachedFromWindow() followed by AllDetached().