### PR TITLE
Fix BMenuField AllDetached callback dispatch

### DIFF
--- a/bindings/interface/MenuField.cpp
+++ b/bindings/interface/MenuField.cpp
@@ -51,7 +51,7 @@ class PyBMenuField : public BMenuField{
             PYBIND11_OVERLOAD(void, BMenuField, DetachedFromWindow);
         }
         void				AllDetached() override {
-            PYBIND11_OVERLOAD(void, BMenuField, AllAttached);
+            PYBIND11_OVERLOAD(void, BMenuField, AllDetached);
         }
         void				FrameMoved(BPoint where) override {
             PYBIND11_OVERLOAD(void, BMenuField, FrameMoved, where);

--- a/tests/menuFieldDetachCallbacks.py
+++ b/tests/menuFieldDetachCallbacks.py
@@ -1,0 +1,63 @@
+from Be import BApplication, BMenu, BMenuField
+
+
+EXPECTED_CALLBACKS = [
+    "DetachedFromWindow",
+    "AllDetached",
+]
+
+
+class CallbackProbe(BMenuField):
+    def __init__(self):
+        self.menu = BMenu("callback-probe-menu")
+
+        BMenuField.__init__(
+            self,
+            "callback-probe",
+            "Callback probe",
+            self.menu,
+        )
+
+        self.calls = []
+
+    def AllAttached(self):
+        self.calls.append("AllAttached")
+
+    def DetachedFromWindow(self):
+        self.calls.append("DetachedFromWindow")
+
+    def AllDetached(self):
+        self.calls.append("AllDetached")
+
+
+def main():
+    application = BApplication(
+        "application/x-vnd.haiku-pyapi-"
+        "menufield-detach-callback-test"
+    )
+
+    field = CallbackProbe()
+
+    # Enter the C++ virtual trampolines through the bound
+    # base methods instead of calling Python overrides directly.
+    BMenuField.DetachedFromWindow(field)
+    BMenuField.AllDetached(field)
+
+    if field.calls != EXPECTED_CALLBACKS:
+        raise SystemExit(
+            "FAIL: incorrect BMenuField detach callback "
+            f"dispatch: {field.calls!r}"
+        )
+
+    print("callbacks =", field.calls)
+    print(
+        "BMENUFIELD DETACH CALLBACK "
+        "REGRESSION TEST: PASS"
+    )
+
+    del field
+    del application
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

PyBMenuField::AllDetached() dispatches to the Python AllAttached() override instead of AllDetached().

## Fix

Use AllDetached as the trampoline target.

## Validation

Verified that detaching through the bound base methods now invokes DetachedFromWindow() and AllDetached().