### PR TITLE
Fix BScrollBar FrameResized callback arguments

### DIFF
--- a/bindings/interface/ScrollBar.cpp
+++ b/bindings/interface/ScrollBar.cpp
@@ -33,7 +33,7 @@ class PyBScrollBar : public BScrollBar{
             PYBIND11_OVERLOAD(void, BScrollBar, FrameMoved, new_position);
         }
         void				FrameResized(float newWidth, float newHeight) override {
-            PYBIND11_OVERLOAD(void, BScrollBar, FrameResized, newWidth, newWidth);
+            PYBIND11_OVERLOAD(void, BScrollBar, FrameResized, newWidth, newHeight);
         }
         void				MessageReceived(BMessage* message) override {
             PYBIND11_OVERLOAD(void, BScrollBar, MessageReceived, message);

--- a/tests/scrollBarFrameResized.py
+++ b/tests/scrollBarFrameResized.py
@@ -1,0 +1,56 @@
+from Be import BApplication, BRect, BScrollBar, B_HORIZONTAL
+
+
+EXPECTED_CALLBACKS = [
+    (123.5, 45.25),
+]
+
+
+class CallbackProbe(BScrollBar):
+    def __init__(self):
+        BScrollBar.__init__(
+            self,
+            BRect(0.0, 0.0, 100.0, 20.0),
+            "frame-resized-probe",
+            None,
+            0.0,
+            100.0,
+            B_HORIZONTAL,
+        )
+
+        self.calls = []
+
+    def FrameResized(self, new_width, new_height):
+        self.calls.append((new_width, new_height))
+
+
+def main():
+    application = BApplication(
+        "application/x-vnd.haiku-pyapi-"
+        "scrollbar-frame-resized-test"
+    )
+
+    scroll_bar = CallbackProbe()
+
+    # Enter the C++ virtual trampoline through the bound
+    # base method instead of calling the Python override directly.
+    BScrollBar.FrameResized(scroll_bar, 123.5, 45.25)
+
+    if scroll_bar.calls != EXPECTED_CALLBACKS:
+        raise SystemExit(
+            "FAIL: incorrect BScrollBar FrameResized "
+            f"callback arguments: {scroll_bar.calls!r}"
+        )
+
+    print("callbacks =", scroll_bar.calls)
+    print(
+        "BSCROLLBAR FRAMERESIZED CALLBACK "
+        "REGRESSION TEST: PASS"
+    )
+
+    del scroll_bar
+    del application
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

PyBScrollBar::FrameResized() forwards newWidth as both callback arguments, so Python overrides never receive the actual height.

## Fix

Pass newHeight as the second argument.

## Validation

Verified that a resize reported as (123.5, 45.25) reaches the Python override unchanged.