### PR TITLE
Fix BControl holder ownership

### DIFF
--- a/bindings/interface/Control.cpp
+++ b/bindings/interface/Control.cpp
@@ -92,7 +92,7 @@ m.attr("B_CONTROL_PARTIALLY_ON") = 2;
 
 //m.attr("BIcon") = BIcon;
 
-py::class_<BControl, PyBControl, BView, BInvoker>(m, "BControl")
+py::class_<BControl, PyBControl, BView, BInvoker, std::unique_ptr<BControl, py::nodelete>>(m, "BControl")
 .def(py::init<BRect, const char *, const char *, BMessage *, unsigned int, unsigned int>(), "", py::arg("frame"), py::arg("name"), py::arg("label"), py::arg("message"), py::arg("resizingMode"), py::arg("flags"))
 .def(py::init<const char *, const char *, BMessage *, unsigned int>(), "", py::arg("name"), py::arg("label"), py::arg("message"), py::arg("flags"))
 .def(py::init<BMessage *>(), "", py::arg("data"))

--- a/tests/controlHolderOwnership.py
+++ b/tests/controlHolderOwnership.py
@@ -1,0 +1,43 @@
+import gc
+
+from Be import (
+    BApplication,
+    BControl,
+    BRect,
+    BWindow,
+    B_NOT_RESIZABLE,
+    window_type,
+)
+
+
+application = BApplication(
+    "application/x-vnd.haiku-pyapi-bcontrol-holder-test"
+)
+
+window = BWindow(
+    BRect(100.0, 100.0, 320.0, 220.0),
+    "BControl holder test",
+    window_type.B_TITLED_WINDOW,
+    B_NOT_RESIZABLE,
+)
+
+control = BControl(
+    BRect(10.0, 10.0, 180.0, 40.0),
+    "holder-probe",
+    "probe",
+    None,
+    0,
+    0,
+)
+
+window.AddChild(control, None)
+window.Quit()
+
+del control
+gc.collect()
+
+del window
+del application
+gc.collect()
+
+print("BCONTROL HOLDER OWNERSHIP REGRESSION TEST: PASS")


### PR DESCRIPTION
## Problem

BControl uses pybind11's default owning holder even after the control has been added to a BWindow.

When the window destroys the attached control, releasing the remaining Python wrapper can attempt to delete it again and abort in Haiku's allocator.

## Fix

Use a py::nodelete holder, matching the ownership model already used by BView.

## Validation

Verified that a window-owned BControl can be destroyed and its Python wrapper released without an allocator abort.