### PR TITLE
Fix BGridView holder ownership

### DIFF
--- a/bindings/interface/GridView.cpp
+++ b/bindings/interface/GridView.cpp
@@ -23,7 +23,7 @@ class PyBGridView : public BGridView{
 
 PYBIND11_MODULE(GridView,m)
 {
-py::class_<BGridView, PyBGridView, BView>(m, "BGridView")
+py::class_<BGridView, PyBGridView, BView, std::unique_ptr<BGridView, py::nodelete>>(m, "BGridView")
 .def(py::init<float, float>(), "", py::arg("horizontal")=B_USE_DEFAULT_SPACING, py::arg("vertical")=B_USE_DEFAULT_SPACING)
 //.def(py::init<float, float>(), "", py::arg("horizontal")=-1002, py::arg("vertical")=-1002)
 .def(py::init<const char *, float, float>(), "", py::arg("name"), py::arg("horizontal")=B_USE_DEFAULT_SPACING, py::arg("vertical")=B_USE_DEFAULT_SPACING)

--- a/tests/gridViewHolderOwnership.py
+++ b/tests/gridViewHolderOwnership.py
@@ -1,0 +1,45 @@
+import gc
+import faulthandler
+
+faulthandler.enable()
+
+try:
+    import resource
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+except Exception:
+    pass
+
+from Be import (
+    BApplication,
+    BGridView,
+    BRect,
+    BWindow,
+    B_NOT_RESIZABLE,
+    window_type,
+)
+
+
+application = BApplication(
+    "application/x-vnd.haiku-pyapi-bgridview-holder-test"
+)
+
+window = BWindow(
+    BRect(100.0, 100.0, 360.0, 260.0),
+    "BGridView holder test",
+    window_type.B_TITLED_WINDOW,
+    B_NOT_RESIZABLE,
+)
+
+grid = BGridView()
+
+window.AddChild(grid, None)
+window.Quit()
+
+del grid
+gc.collect()
+
+del window
+del application
+gc.collect()
+
+print("BGRIDVIEW HOLDER OWNERSHIP REGRESSION TEST: PASS")


### PR DESCRIPTION
## Problem

An attached BGridView is owned and destroyed by its BWindow, while the Python wrapper still retains deletion responsibility.

Releasing the wrapper can therefore attempt a second deletion during finalization.

## Fix

Bind BGridView with a py::nodelete holder.

## Validation

Verified that window shutdown and Python finalization complete cleanly for an attached BGridView.