### PR TITLE
Fix BSeparatorView holder ownership

### DIFF
--- a/bindings/interface/SeparatorView.cpp
+++ b/bindings/interface/SeparatorView.cpp
@@ -38,7 +38,7 @@ class PyBSeparatorView : public BSeparatorView{
 
 PYBIND11_MODULE(SeparatorView,m)
 {
-py::class_<BSeparatorView, PyBSeparatorView, BView>(m, "BSeparatorView")
+py::class_<BSeparatorView, PyBSeparatorView, BView, std::unique_ptr<BSeparatorView, py::nodelete>>(m, "BSeparatorView")
 .def(py::init<orientation, border_style>(), "", py::arg("orientation"), py::arg("border")=B_PLAIN_BORDER)
 .def(py::init<const char *, const char *, orientation, border_style, const BAlignment &>(), "", py::arg("name"), py::arg("label"), py::arg("orientation")=B_HORIZONTAL, py::arg("border")=B_FANCY_BORDER, py::arg("alignment")=BAlignment(B_ALIGN_HORIZONTAL_CENTER,B_ALIGN_VERTICAL_CENTER))
 .def(py::init<const char *, BView *, orientation, border_style, const BAlignment &>(), "", py::arg("name"), py::arg("labelView"), py::arg("orientation")=B_HORIZONTAL, py::arg("border")=B_FANCY_BORDER, py::arg("alignment")=BAlignment(B_ALIGN_HORIZONTAL_CENTER,B_ALIGN_VERTICAL_CENTER))

--- a/tests/separatorViewHolderOwnership.py
+++ b/tests/separatorViewHolderOwnership.py
@@ -1,0 +1,46 @@
+import gc
+import faulthandler
+
+faulthandler.enable()
+
+try:
+    import resource
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+except Exception:
+    pass
+
+from Be import (
+    BApplication,
+    BSeparatorView,
+    BRect,
+    BWindow,
+    B_HORIZONTAL,
+    B_NOT_RESIZABLE,
+    window_type,
+)
+
+
+application = BApplication(
+    "application/x-vnd.haiku-pyapi-bseparatorview-holder-test"
+)
+
+window = BWindow(
+    BRect(100.0, 100.0, 360.0, 260.0),
+    "BSeparatorView holder test",
+    window_type.B_TITLED_WINDOW,
+    B_NOT_RESIZABLE,
+)
+
+separator = BSeparatorView(B_HORIZONTAL)
+
+window.AddChild(separator, None)
+window.Quit()
+
+del separator
+gc.collect()
+
+del window
+del application
+gc.collect()
+
+print("BSEPARATORVIEW HOLDER OWNERSHIP REGRESSION TEST: PASS")


### PR DESCRIPTION
## Problem

BSeparatorView uses an owning Python holder even after its lifetime has been transferred to a BWindow.

This can cause a second deletion attempt when the Python wrapper is released.

## Fix

Bind BSeparatorView with a py::nodelete holder.

## Validation

Verified that an attached separator can be destroyed with its window and finalized without an allocator abort.