### PR TITLE
Activate BSplitView binding

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -175,6 +175,7 @@ local sourceFiles =
 	SeparatorItem.cpp
 	Alignment.cpp
 	SeparatorView.cpp
+	SplitView.cpp
 	MenuBar.cpp
 	StatusBar.cpp
 	CheckBox.cpp

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -52,6 +52,7 @@ from .Box import *
 from .SeparatorItem import *
 from .Alignment import *
 from .SeparatorView import *
+from .SplitView import *
 from .MenuBar import *
 from .StatusBar import *
 from .CheckBox import *

--- a/bindings/interface/SplitView.cpp
+++ b/bindings/interface/SplitView.cpp
@@ -4,6 +4,8 @@
 #include <pybind11/operators.h>
 
 #include <interface/SplitView.h>
+#include <Layout.h>
+#include <LayoutItem.h>
 #include <View.h>
 
 namespace py = pybind11;
@@ -11,7 +13,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(SplitView,m)
 {
-py::class_<BSplitView, BView>(m, "BSplitView")
+py::class_<BSplitView, BView, std::unique_ptr<BSplitView, py::nodelete>>(m, "BSplitView")
 .def(py::init<orientation, float>(), "", py::arg("orientation")=B_HORIZONTAL, py::arg("spacing")=B_USE_DEFAULT_SPACING)
 .def(py::init<BMessage *>(), "", py::arg("from"))
 .def("SetInsets", py::overload_cast<float, float, float, float>(&BSplitView::SetInsets), "", py::arg("left"), py::arg("top"), py::arg("right"), py::arg("bottom"))
@@ -25,8 +27,8 @@ py::class_<BSplitView, BView>(m, "BSplitView")
 .def("SplitterSize", &BSplitView::SplitterSize, "")
 .def("SetSplitterSize", &BSplitView::SetSplitterSize, "", py::arg("size"))
 .def("CountItems", &BSplitView::CountItems, "")
-.def("ItemWeight", py::overload_cast<int>(&BSplitView::ItemWeight), "", py::arg("index"))
-.def("ItemWeight", py::overload_cast<BLayoutItem *>(&BSplitView::ItemWeight), "", py::arg("item"))
+.def("ItemWeight", py::overload_cast<int>(&BSplitView::ItemWeight, py::const_), "", py::arg("index"))
+.def("ItemWeight", py::overload_cast<BLayoutItem *>(&BSplitView::ItemWeight, py::const_), "", py::arg("item"))
 .def("SetItemWeight", py::overload_cast<int, float, bool>(&BSplitView::SetItemWeight), "", py::arg("index"), py::arg("weight"), py::arg("invalidateLayout"))
 .def("SetItemWeight", py::overload_cast<BLayoutItem *, float>(&BSplitView::SetItemWeight), "", py::arg("item"), py::arg("weight"))
 .def("IsCollapsible", &BSplitView::IsCollapsible, "", py::arg("index"))

--- a/tests/splitViewHolderOwnership.py
+++ b/tests/splitViewHolderOwnership.py
@@ -1,0 +1,46 @@
+import gc
+import faulthandler
+
+faulthandler.enable()
+
+try:
+    import resource
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+except Exception:
+    pass
+
+from Be import (
+    BApplication,
+    BRect,
+    BSplitView,
+    BWindow,
+    B_HORIZONTAL,
+    B_NOT_RESIZABLE,
+    window_type,
+)
+
+
+application = BApplication(
+    "application/x-vnd.haiku-pyapi-bsplitview-holder-test"
+)
+
+window = BWindow(
+    BRect(100.0, 100.0, 360.0, 260.0),
+    "BSplitView holder test",
+    window_type.B_TITLED_WINDOW,
+    B_NOT_RESIZABLE,
+)
+
+split = BSplitView(B_HORIZONTAL)
+
+window.AddChild(split, None)
+window.Quit()
+
+del split
+gc.collect()
+
+del window
+del application
+gc.collect()
+
+print("BSPLITVIEW HOLDER OWNERSHIP REGRESSION TEST: PASS")


### PR DESCRIPTION
## Problem

SplitView.cpp exists but is not included in the Jam build or exported by the Be package, so BSplitView is unavailable to Python callers.

Enabling the source also exposes incomplete layout types, incorrect bindings for the const ItemWeight() overloads, and an owning holder that conflicts with BWindow ownership.

## Fix

Add SplitView.cpp to the build and package exports, include the complete layout types, bind both const overloads with py::const_, and use a py::nodelete holder.

## Validation

Verified that SplitView.so builds and imports successfully and that a window-owned BSplitView shuts down without an allocator abort.