### PR TITLE
Fix BMenuItem shortcut default

### DIFF
--- a/bindings/interface/MenuItem.cpp
+++ b/bindings/interface/MenuItem.cpp
@@ -41,7 +41,7 @@ PYBIND11_MODULE(MenuItem,m)
 //m.attr("MenuItemPrivate") = MenuItemPrivate;
 
 py::class_<BMenuItem, PyBMenuItem, BInvoker, std::unique_ptr<BMenuItem, py::nodelete>>(m, "BMenuItem")
-.def(py::init<const char *, BMessage *, char, unsigned int>(), "", py::arg("label"), py::arg("message"), py::arg("shortcut")=0, py::arg("modifiers")=0)
+.def(py::init<const char *, BMessage *, char, unsigned int>(), "", py::arg("label"), py::arg("message"), py::arg("shortcut")='\0', py::arg("modifiers")=0)
 .def(py::init<BMenu *, BMessage *>(), "", py::arg("menu"), py::arg("message")=NULL)
 .def(py::init<BMessage *>(), "", py::arg("data"))
 .def_static("Instantiate", &BMenuItem::Instantiate, "", py::arg("archive"))

--- a/tests/menuItemShortcutDefault.py
+++ b/tests/menuItemShortcutDefault.py
@@ -1,0 +1,23 @@
+import gc
+
+from Be import BMenuItem, BMessage
+
+
+message = BMessage(0x716D6903)
+
+item = BMenuItem(
+    "default shortcut",
+    message,
+)
+
+if item.Label() != "default shortcut":
+    raise RuntimeError(
+        f"unexpected menu item label: {item.Label()!r}"
+    )
+
+del item
+del message
+
+gc.collect()
+
+print("BMENUITEM DEFAULT SHORTCUT REGRESSION TEST: PASS")


### PR DESCRIPTION
## Problem

The optional BMenuItem shortcut is registered with the integer default 0, but pybind11 exposes the bound C++ char parameter as a Python string.

Constructing a menu item without an explicit shortcut therefore fails argument conversion.

## Fix

Use the null character '\0' as the default value.

## Validation

Verified construction without a shortcut and with explicit null and key shortcuts.