### PR TITLE
Fix Invoke message defaults

### DIFF
--- a/bindings/app/Invoker.cpp
+++ b/bindings/app/Invoker.cpp
@@ -211,7 +211,7 @@ If message is ``None`` the default message is sent instead.
 :type message: BMessage
 :return: ``B_OK`` if the message was sent, ``B_BAD_VALUE`` for no default message, and no message argument, other error forwarded from BMessenger::SendMessage().
 :rtype: int
-)doc", py::arg("message")=NULL)
+)doc", py::arg("message")=py::none())
 .def("InvokeNotify", &BInvoker::InvokeNotify, R"doc(
 Send the message to its target, using the notification code specified by kind.
 If message is ``None``, no message is sent to the target, but any watchers of the 

--- a/bindings/interface/Button.cpp
+++ b/bindings/interface/Button.cpp
@@ -135,7 +135,7 @@ py::class_<BButton,PyBButton,BControl,BView,std::unique_ptr<BButton, py::nodelet
 .def("SetValue", &BButton::SetValue, "", py::arg("value"))
 .def("GetPreferredSize", &BButton::GetPreferredSize, "", py::arg("_width"), py::arg("_height"))
 .def("ResizeToPreferred", &BButton::ResizeToPreferred, "")
-.def("Invoke", &BButton::Invoke, "", py::arg("message")=NULL)
+.def("Invoke", &BButton::Invoke, "", py::arg("message")=py::none())
 .def("FrameMoved", &BButton::FrameMoved, "", py::arg("newPosition"))
 .def("FrameResized", &BButton::FrameResized, "", py::arg("newWidth"), py::arg("newHeight"))
 .def("MakeFocus", &BButton::MakeFocus, "", py::arg("focus")=true)

--- a/tests/invokeMessageDefault.py
+++ b/tests/invokeMessageDefault.py
@@ -1,0 +1,90 @@
+import faulthandler
+import gc
+
+faulthandler.enable()
+
+try:
+    import resource
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+except Exception:
+    pass
+
+from Be import (
+    BApplication,
+    BButton,
+    BInvoker,
+    BMessage,
+)
+
+
+SENTINEL = 23117
+
+
+class SafeButton(BButton):
+    def __init__(self):
+        super().__init__(
+            "safe default-argument button",
+            BMessage(0x71646274),
+        )
+        self.received = "not-called"
+
+    def Invoke(self, message=None):
+        self.received = message
+        return SENTINEL
+
+
+class SafeInvoker(BInvoker):
+    def __init__(self):
+        super().__init__()
+        self.received = "not-called"
+
+    def Invoke(self, message=None):
+        self.received = message
+        return SENTINEL
+
+
+application = BApplication(
+    "application/x-vnd.haiku-pyapi-invoke-default-test"
+)
+
+button = SafeButton()
+
+button_result = BButton.Invoke(button)
+
+if button_result != SENTINEL:
+    raise RuntimeError(
+        f"BButton trampoline returned {button_result!r}"
+    )
+
+if button.received is not None:
+    raise RuntimeError(
+        f"BButton received {button.received!r}"
+    )
+
+print("BBUTTON INVOKE DEFAULT REGRESSION: PASS")
+
+
+invoker = SafeInvoker()
+
+invoker_result = BInvoker.Invoke(invoker)
+
+if invoker_result != SENTINEL:
+    raise RuntimeError(
+        f"BInvoker trampoline returned {invoker_result!r}"
+    )
+
+if invoker.received is not None:
+    raise RuntimeError(
+        f"BInvoker received {invoker.received!r}"
+    )
+
+print("BINVOKER INVOKE DEFAULT REGRESSION: PASS")
+
+
+del invoker
+del button
+del application
+
+gc.collect()
+
+print("INVOKE MESSAGE DEFAULT REGRESSION TEST: PASS")


### PR DESCRIPTION
## Summary

* use Python `None` as the default for optional `BMessage*` arguments in `BButton.Invoke()` and `BInvoker.Invoke()`
* add a regression test covering both bindings

## Background

Both methods accept an optional native `BMessage*`:

```cpp
status_t Invoke(BMessage* message = NULL)
```

The bindings registered the pointer default as C++ `NULL`:

```cpp
py::arg("message") = NULL
```

Pybind11 exposed this as the Python integer `0`:

```text
BButton.Invoke(message: BMessage = 0)
BInvoker.Invoke(message: BMessage = 0)
```

Calling either method without an argument therefore failed during argument conversion:

```text
TypeError: Invoke(): incompatible function arguments
```

Passing `None` explicitly was accepted, confirming that the pointer conversion itself was valid and only the registered default was incorrect.

## Fix

Register the optional pointer arguments using Python `None`:

```cpp
py::arg("message") = py::none()
```

The resulting Python signatures now correctly advertise:

```text
BButton.Invoke(message: BMessage = None)
BInvoker.Invoke(message: BMessage = None)
```

## Validation

* reproduced the omitted-argument failure for both bindings
* verified that explicit `None` converts correctly
* used Python trampoline subclasses so the native invocation mechanism was not executed during regression testing
* rebuilt `Button.so` and `Invoker.so`
* verified omitted arguments reach both trampolines as `None`
* verified explicit `BMessage` arguments remain compatible
* verified both generated Python signatures advertise `None` instead of `0`
* independently applied the patch against upstream `main` at `99940f7620ce6860bdb993922308079160e4fbad`
* independently reproduced both module artifacts
* independently reran the regression, signature, and explicit-message compatibility tests successfully
